### PR TITLE
Use preemptible VMs in GCP

### DIFF
--- a/conf/gcp_debug.config
+++ b/conf/gcp_debug.config
@@ -24,6 +24,10 @@ google {
     zone = 'us-central1-a'
 }
 
+cloud {
+	preemptible = true
+}
+
 executor {
     queueSize = 4
 }


### PR DESCRIPTION
Setting `preemptible = true` will allow you to save money when using Google Cloud VMs. If the VM is preempted (I.e., killed), your job will restart automatically.